### PR TITLE
use system configured from name and from email

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,43 @@
 # ZPool, SMART, and UPS Status Report with TrueNAS Config Backup
-Original Script By: joeschmuck<br>
-Modified By: bidelu0hm, melp, fohlsso2, onlinepcwizard, ninpucho, isentropik, rotx, dak180<br>
-Last Edited By: dak180
-
-Preview of the output here: https://i.imgur.com/jKwraw4.png<br>
-When a resilver is in progress: https://i.imgur.com/CUNUZ7r.png<br>
-After the resilver is done: https://i.imgur.com/I43MLLf.png<br>
-When a scrub is in progess: https://i.imgur.com/YGmvZT4.png<br><br>
-
-**At a minimum, enter email address and set defaultFile to 0 in the generated config file. Feel free to edit other user parameters as needed. Backup has been disabled by default so if it is required please set to true.**<br><br>
 
 **Current Version: v1.7**
 
-**Changelog:**
+Preview of the output here: https://i.imgur.com/jKwraw4.png
+
+When a resilver is in progress: https://i.imgur.com/CUNUZ7r.png
+
+After the resilver is done: https://i.imgur.com/I43MLLf.png
+
+When a scrub is in progess: https://i.imgur.com/YGmvZT4.png
+
+# Get Started
+
+Place the script under a user `/home/user` or in one of your pools.
+
+Create a Cron Job with the following configuration:
+
+```
+Description: Run Smart Report
+Command: /mnt/pool/storage/smartreport.sh -c /mnt/pool/storage/smartreport.conf
+Run as: root
+Schedule: Daily
+Hide Standard Output: **Checked**
+Enabled: **Checked**
+```
+
+Click `Submit` and then `Run Now`.
+
+A configuration file will be generated at `/mnt/pool/storage/smartreport.conf`
+
+Make sure the email credentials are configured in `System -> Email`. 
+
+> `From Email` and `From Name` are required
+
+At a minimum, enter an email address for the report to be sent to and set `defaultFile` to 0 in the generated config file. Feel free to edit other user parameters as needed. Backup has been disabled by default so if it is required please set to true.
+
+Once you have updated the config file, click `Run Now` again to generate your first report.
+
+# Changelog
 
 *v1.7* (dak180)
  - Refactor to reduce dependence on awk
@@ -77,3 +102,10 @@ When a scrub is in progess: https://i.imgur.com/YGmvZT4.png<br><br>
 
 *v1.0*
 - Initial release
+
+# Contributors
+Original Script By: joeschmuck
+
+Modified By: bidelu0hm, melp, fohlsso2, onlinepcwizard, ninpucho, isentropik, rotx, dak180
+
+Last Edited By: dak180

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Command: /mnt/pool/storage/smartreport.sh -c /mnt/pool/storage/smartreport.conf
 Run as: root
 Schedule: Daily
 Hide Standard Output: **Checked**
+Hide Standard Error: **Unchecked**
 Enabled: **Checked**
 ```
 
@@ -36,6 +37,14 @@ Make sure the email credentials are configured in `System -> Email`.
 At a minimum, enter an email address for the report to be sent to and set `defaultFile` to 0 in the generated config file. Feel free to edit other user parameters as needed. Backup has been disabled by default so if it is required please set to true.
 
 Once you have updated the config file, click `Run Now` again to generate your first report.
+
+# SMART Tests
+
+You should also configure running your smart tests otherwise the script will not include smart test results and will generate an additional error unless you checked `Hide Standard Error` in the cron job.
+
+You can configure a `SHORT` SMART test to run daily at 11pm before the report is generated.
+
+A `LONG` SMART test can be configured to run once a month.
 
 # Changelog
 

--- a/report.sh
+++ b/report.sh
@@ -1285,6 +1285,8 @@ fi
 
 ###### Auto-generated Parameters
 host="$(hostname -s)"
+fromEmail="$(sqlite3 /data/freenas-v1.db "select em_fromemail from system_email;")"
+fromName="$(sqlite3 /data/freenas-v1.db "select em_fromname from system_email;")"
 runDate="$(date '+%s')"
 logfile="${logfileLocation}/$(date -r "${runDate}" '+%Y%m%d%H%M%S')_${logfileName}.tmp"
 subject="Status Report and Configuration Backup for ${host} - $(date -r "${runDate}" '+%Y-%m-%d %H:%M')"
@@ -1333,7 +1335,7 @@ readarray -t "pools" <<< "$(zpool list -H -o name)"
 ###### Email pre-formatting
 ### Set email headers
 {
-    echo "From: ${host} <root@$(hostname)>"
+    echo "From: ${fromName} <${fromEmail}>"
     echo "To: ${email}"
     echo "Subject: ${subject}"
     echo "MIME-Version: 1.0"


### PR DESCRIPTION
This change should probably resolve:

https://github.com/edgarsuit/FreeNAS-Report/issues/26

Most likely the emails are getting rejected due to the from email being different from what was configured in the system.

This of course depends on the mail provider used and if they allow arbitrary from emails.