### PR TITLE
Colorize smart test status for SAS drives

### DIFF
--- a/report.sh
+++ b/report.sh
@@ -1240,13 +1240,13 @@ function SASSummary () {
 				lastTestHours=""
 			fi
 
-            # Mimic the true/false response expected from json in the future
-            if [ "${lastTestStatus}" = "- [- - -]" ] || [ "${lastTestType}" = "N/A" ]; then 
-                lastTestStatus="true"
-            else
-                lastTestStatus="false"
-            fi
-            
+			# Mimic the true/false response expected from json in the future
+			if [ "${lastTestStatus}" = "- [- - -]" ] || [ "${lastTestType}" = "N/A" ]; then 
+				lastTestStatus="true"
+			else
+				lastTestStatus="false"
+			fi
+
 			# Available for any drive smartd knows about
 			if [ "$(echo "${sasInfoSmrt}" | jq -Mre '.smart_status.passed | values')" = "true" ]; then
 				local smartStatus="PASSED"
@@ -1381,7 +1381,7 @@ function SASSummary () {
 				local testAgeColor="${bgColor}"
 			fi
 
-            # Colorize Smart test Status
+			# Colorize Smart test Status
 			if [ "${lastTestStatus}" = "false" ]; then
 				local lastTestStatusColor="${critColor}"
 			else


### PR DESCRIPTION
I don't have any SAS drives that are currently failing self tests, but these changes work fine on my servers with healthy SAS drives.  They detect the "passing" state of no LBA or KCQ listed in the self test result (i.e. "- [ - - - ]") and set the color to the normal background color.  Any deviation from this expected pattern would indicate a self test failure and use the critical color instead.

I set it up to mimic the previous code on SATA drives, and to be "ready" for if json format is supported in the future.