### PR TITLE
Fix for out of order check on lastTestType prior to setting it to 'N/A'

### DIFF
--- a/report.sh
+++ b/report.sh
@@ -1234,17 +1234,18 @@ function SASSummary () {
 			lastTestStatus="$(echo "${nonJsonSasInfoSmrt}" | grep '# 1' | tr -s " " | cut -d ' ' -sf '8,9,10,11')"
 
 			# Mimic the true/false response expected from json in the future
-			if [ "${lastTestStatus}" = "- [- - -]" ] || [ "${lastTestType}" = "N/A" ]; then
+			if [ "${lastTestStatus}" = "- [- - -]" ] || 
 				lastTestStatus="true"
 			else
-				lastTestStatus="false"
-			fi
-
-			# Workaround for some drives that do not support self testing but still report a garbage self test log
-			# Set last test type to 'N/A' and last test hours to null "" in this case
-			if [ "${lastTestType}" == "Default Self" ]; then
-				lastTestType="N/A"
-				lastTestHours=""
+				# Workaround for some drives that do not support self testing but still report a garbage self test log
+				# Set last test type to 'N/A' and last test hours to null "" in this case.  Do not colorize test status as a failure.
+				if [ "${lastTestType}" == "Default Self" ]; then
+					lastTestType="N/A"
+					lastTestHours=""
+					lastTestStatus="true"
+				else
+					lastTestStatus="false"
+				fi
 			fi
 
 			# Available for any drive smartd knows about

--- a/report.sh
+++ b/report.sh
@@ -1234,7 +1234,7 @@ function SASSummary () {
 			lastTestStatus="$(echo "${nonJsonSasInfoSmrt}" | grep '# 1' | tr -s " " | cut -d ' ' -sf '8,9,10,11')"
 
 			# Mimic the true/false response expected from json in the future
-			if [ "${lastTestStatus}" = "- [- - -]" ] || 
+			if [ "${lastTestStatus}" = "- [- - -]" ]; then
 				lastTestStatus="true"
 			else
 				# Workaround for some drives that do not support self testing but still report a garbage self test log

--- a/report.sh
+++ b/report.sh
@@ -766,7 +766,13 @@ function SSDSummary () {
 			# Get more useful times from hours
 			local testAge=""
 			if [ ! -z "${lastTestHours}" ]; then
-				testAge="$(bc <<< "(${onHours} - ${lastTestHours}) / 24")"
+				# Check whether the selftest log times have overflowed after 65,535 hours of total power-on time
+				overflowTest="$((${onHours} - ${lastTestHours}))"
+				if [ "${overflowTest}" -gt "65535" ]; then # Correct the overflow if necessary
+					testAge="$(bc <<< "(${onHours} - ${lastTestHours} - 65535) / 24")"
+				else # Normal Case, no overflow
+					testAge="$(bc <<< "(${onHours} - ${lastTestHours}) / 24")"
+				fi
 			fi
 
 			local yrs="$(bc <<< "${onHours} / 8760")"
@@ -1026,7 +1032,13 @@ function HDDSummary () {
 			# Get more useful times from hours
 			local testAge=""
 			if [ ! -z "${lastTestHours}" ]; then
-				testAge="$(bc <<< "(${onHours} - ${lastTestHours}) / 24")"
+				# Check whether the selftest log times have overflowed after 65,535 hours of total power-on time
+				overflowTest="$((${onHours} - ${lastTestHours}))"
+				if [ "${overflowTest}" -gt "65535" ]; then # Correct the overflow if necessary
+					testAge="$(bc <<< "(${onHours} - ${lastTestHours} - 65535) / 24")"
+				else # Normal Case, no overflow
+					testAge="$(bc <<< "(${onHours} - ${lastTestHours}) / 24")"
+				fi
 			fi
 
 			local yrs="$(bc <<< "${onHours} / 8760")"
@@ -1282,7 +1294,13 @@ function SASSummary () {
 			# Get more useful times from hours
 			local testAge=""
 			if [ ! -z "${lastTestHours}" ]; then
-				testAge="$(bc <<< "(${onHours} - ${lastTestHours}) / 24")"
+				# Check whether the selftest log times have overflowed after 65,535 hours of total power-on time
+				overflowTest="$((${onHours} - ${lastTestHours}))"
+				if [ "${overflowTest}" -gt "65535" ]; then # Correct the overflow if necessary
+					testAge="$(bc <<< "(${onHours} - ${lastTestHours} - 65535) / 24")"
+				else # Normal Case, no overflow
+					testAge="$(bc <<< "(${onHours} - ${lastTestHours}) / 24")"
+				fi
 			fi
 
 			local yrs="$(bc <<< "${onHours} / 8760")"


### PR DESCRIPTION
After your re-arranging of these two code blocks, I thought combining them as a single nested block actually makes the most sense?  This way I believe it's even more obvious that the inner block is just a workaround for some badly behaved drives?  And this seems better than testing for "Default Self" twice, in two separate code blocks.